### PR TITLE
fix(interceptor): emulate child_process better

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -219,10 +219,13 @@ class Interceptor {
     this.child.stderr = new stream.PassThrough({ autoDestroy: true })
     this.child.stdio = [this.child.stdin, this.child.stdout, this.child.stderr]
     this.child.spawnargs = args
+    this.child.spawnfile = command
+    this.child.connected = true
     this.child.kill = (signal) => {
+      this.child.killed = true
       this.child.emit(signal, signal)
     }
-    this.child.emit('spawn')
+
     const exit = async () => {
       const [exitCode, signal, stdout, stderr] = await Promise.all(
         [this.exitCode, this.signal, this.stdout, this.stderr]
@@ -230,6 +233,7 @@ class Interceptor {
       this.child.exitCode = exitCode
       this.child.signalCode = signal
       this.child.connected = false
+      this.child.emit('disconnect')
       if (stdout) {
         this.child.stdout.write(stdout)
       }
@@ -241,6 +245,13 @@ class Interceptor {
       this.child.emit('exit', exitCode, signal)
       this.child.emit('close', exitCode, signal)
     }
+
+    // give whatever called spawn a chance to set up listeners
+    process.nextTick(() => {
+      // TODO support error event if child process does not spawn correctly.
+      this.child.emit('spawn')
+    })
+
     if (this.exitOnSignal) {
       this.child.on(this.exitOnSignal, exit)
     } else {

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -82,11 +82,15 @@ const fixtures = {
     return signal
   },
 
-  exitPromise: (spawned) => new Promise((resolve) => {
-    spawned.on('exit', (code, signal) => {
+  eventPromise: (event, spawned) => new Promise((resolve) => {
+    spawned.on(event, (code, signal) => {
       resolve({ code, signal })
     })
   }),
+
+  spawnPromise: (spawned) => fixtures.eventPromise('spawn', spawned),
+  exitPromise: (spawned) => fixtures.eventPromise('exit', spawned),
+  disconnectPromise: (spawned) => fixtures.eventPromise('disconnect', spawned),
 
   stdoutPromise: (spawned) => new Promise((resolve) => {
     let output


### PR DESCRIPTION
Adds the `connected`, `spawnfile`, and `killed` attributes.
Emits the `disconnected` event
Moved `spawn` event emission to process.nextTick so the calling function
has a chance to register a listener.