### PR TITLE
fix(spawnError): work with delay and exitOnSignal

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,4 +188,7 @@ change it via `interceptor.signal`.
 Tells the interceptor to emit the given error object via the `error`
 event, instead of the normal `spawn` event.  The interceptor will not
 emit the `exit` or `close` events in this case, nor will it set up any
-stdio objects.
+stdio objects.  This can be combined with `interceptor.delay` to delay
+this error, or this can be combined with `interceptor.exitOnSignal` to
+erroring when the given signal is received (replicating a process that
+can not be killed).

--- a/README.md
+++ b/README.md
@@ -189,6 +189,5 @@ Tells the interceptor to emit the given error object via the `error`
 event, instead of the normal `spawn` event.  The interceptor will not
 emit the `exit` or `close` events in this case, nor will it set up any
 stdio objects.  This can be combined with `interceptor.delay` to delay
-this error, or this can be combined with `interceptor.exitOnSignal` to
-erroring when the given signal is received (replicating a process that
-can not be killed).
+this error, or with `interceptor.exitOnSignal` to error when the given
+signal is received (replicating a process that can not be killed).

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -77,13 +77,9 @@ class API {
     return this.description
   }
 
-  error (err) {
+  spawnError (err) {
     this[_interceptor].spawnError = err
     return this
-  }
-
-  spawnError (err) {
-    return this.error(err)
   }
 
   exit (code) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -252,13 +252,11 @@ class Interceptor {
         this.child.emit('error', this.spawnError)
       }, this.delay)
     } else {
-      if (!this.spawnError) {
-        this.child.connected = true
-        this.child.stdin = new stream.PassThrough({ autoDestroy: true })
-        this.child.stdout = new stream.PassThrough({ autoDestroy: true })
-        this.child.stderr = new stream.PassThrough({ autoDestroy: true })
-        this.child.stdio = [this.child.stdin, this.child.stdout, this.child.stderr]
-      }
+      this.child.connected = true
+      this.child.stdin = new stream.PassThrough({ autoDestroy: true })
+      this.child.stdout = new stream.PassThrough({ autoDestroy: true })
+      this.child.stderr = new stream.PassThrough({ autoDestroy: true })
+      this.child.stdio = [this.child.stdin, this.child.stdout, this.child.stderr]
       this.child.kill = (signal) => {
         if (!this.spawnError) {
           this.child.killed = true

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -77,9 +77,13 @@ class API {
     return this.description
   }
 
-  spawnError (err) {
+  error (err) {
     this[_interceptor].spawnError = err
     return this
+  }
+
+  spawnError (err) {
+    return this.error(err)
   }
 
   exit (code) {
@@ -104,11 +108,6 @@ class API {
     this[_interceptor].exitOnSignal = signal
     return this
   }
-
-  // errorOnSignal (signal) {
-  //   this[_interceptor].errorOnSignal = signal
-  //   return this
-  // }
 
   stdout (stdout) {
     this[_interceptor].stdout = stdout
@@ -248,12 +247,10 @@ class Interceptor {
       this.child.emit('close', exitCode, signal)
     }
 
-    // process.nextTick here is to give whatever called spawn a chance to set
-    // up listeners
-    if (this.spawnError) {
-      process.nextTick(() => {
+    if (this.spawnError && !this.exitOnSignal) {
+      setTimeout(() => {
         this.child.emit('error', this.spawnError)
-      })
+      }, this.delay)
     } else {
       this.child.connected = true
       this.child.stdin = new stream.PassThrough({ autoDestroy: true })
@@ -264,12 +261,19 @@ class Interceptor {
         this.child.killed = true
         this.child.emit(signal, signal)
       }
+      // process.nextTick to give the caller a chance to set up listeners
       process.nextTick(() => {
         this.child.emit('spawn')
       })
 
       if (this.exitOnSignal) {
-        this.child.on(this.exitOnSignal, exit)
+        if (this.spawnError) {
+          this.child.on(this.exitOnSignal, () => {
+            this.child.emit('error', this.spawnError)
+          })
+        } else {
+          this.child.on(this.exitOnSignal, exit)
+        }
       } else {
         setTimeout(exit, this.delay)
       }

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -252,13 +252,17 @@ class Interceptor {
         this.child.emit('error', this.spawnError)
       }, this.delay)
     } else {
-      this.child.connected = true
-      this.child.stdin = new stream.PassThrough({ autoDestroy: true })
-      this.child.stdout = new stream.PassThrough({ autoDestroy: true })
-      this.child.stderr = new stream.PassThrough({ autoDestroy: true })
-      this.child.stdio = [this.child.stdin, this.child.stdout, this.child.stderr]
+      if (!this.spawnError) {
+        this.child.connected = true
+        this.child.stdin = new stream.PassThrough({ autoDestroy: true })
+        this.child.stdout = new stream.PassThrough({ autoDestroy: true })
+        this.child.stderr = new stream.PassThrough({ autoDestroy: true })
+        this.child.stdio = [this.child.stdin, this.child.stdout, this.child.stderr]
+      }
       this.child.kill = (signal) => {
-        this.child.killed = true
+        if (!this.spawnError) {
+          this.child.killed = true
+        }
         this.child.emit(signal, signal)
       }
       // process.nextTick to give the caller a chance to set up listeners

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -86,22 +86,26 @@ const fixtures = {
     return signal
   },
 
-  errorPromise: (spawned) => new Promise((resolve) => {
-    spawned.on('error', resolve)
-  }),
-
-  spawnPromise: (spawned) => new Promise((resolve) => {
-    spawned.on('spawn', resolve)
+  closePromise: (spawned) => new Promise((resolve) => {
+    spawned.on('close', resolve)
   }),
 
   disconnectPromise: (spawned) => new Promise((resolve) => {
     spawned.on('disconnect', resolve)
   }),
 
+  errorPromise: (spawned) => new Promise((resolve) => {
+    spawned.on('error', resolve)
+  }),
+
   exitPromise: (spawned) => new Promise((resolve) => {
     spawned.on('exit', (code, signal) => {
       resolve({ code, signal })
     })
+  }),
+
+  spawnPromise: (spawned) => new Promise((resolve) => {
+    spawned.on('spawn', resolve)
   }),
 
   stdoutPromise: (spawned) => new Promise((resolve) => {

--- a/test/interceptor.js
+++ b/test/interceptor.js
@@ -23,11 +23,16 @@ describe('interceptor', () => {
     const spawnPromise = Fixtures.spawnPromise(spawned)
     const exitPromise = Fixtures.exitPromise(spawned)
     const disconnectPromise = Fixtures.disconnectPromise(spawned)
+    const closePromise = Fixtures.disconnectPromise(spawned)
+    const stdoutPromise = Fixtures.stdoutPromise(spawned)
+    const stderrPromise = Fixtures.stderrPromise(spawned)
+
     const { code, signal } = await exitPromise
-    await disconnectPromise
     await spawnPromise
-    const stdout = await Fixtures.stdoutPromise(spawned)
-    const stderr = await Fixtures.stderrPromise(spawned)
+    await disconnectPromise
+    await closePromise
+    const stdout = await stdoutPromise
+    const stderr = await stderrPromise
 
     expect(code, 'exit code').to.equal(0)
     expect(spawned.spawnfile, 'spawnfile').to.equal(command)
@@ -151,6 +156,7 @@ describe('interceptor', () => {
 
       expect(signal, 'exit signal').to.equal(otherSignal)
       expect(mocked.called, 'spawned called').to.equal(true)
+      expect(spawned.killed).to.equal(true)
     })
 
     it('other signal configured second', async () => {
@@ -182,6 +188,9 @@ describe('interceptor', () => {
       const caught = await Fixtures.errorPromise(spawned)
       expect(caught.message).to.equal(error.message)
       expect(spawned.connected, 'connected').to.equal(false)
+      expect(spawned.stdin).to.equal(undefined)
+      expect(spawned.stdout).to.equal(undefined)
+      expect(spawned.stderr).to.equal(undefined)
     })
 
     it('combined with delay', async () => {
@@ -195,6 +204,9 @@ describe('interceptor', () => {
       const after = new Date()
       expect(after - before).to.be.at.least(delay - 10)
       expect(caught.message).to.equal(error.message)
+      expect(spawned.stdin).to.equal(undefined)
+      expect(spawned.stdout).to.equal(undefined)
+      expect(spawned.stderr).to.equal(undefined)
     })
 
     it('combined with exitOnSignal', async () => {
@@ -209,6 +221,10 @@ describe('interceptor', () => {
       const caught = await errorPromise
       expect(mocked.called, 'spawned called').to.equal(true)
       expect(caught.message, 'error message').to.equal(error.message)
+      expect(spawned.killed).to.not.equal(true)
+      expect(spawned.stdin).to.equal(undefined)
+      expect(spawned.stdout).to.equal(undefined)
+      expect(spawned.stderr).to.equal(undefined)
     })
   })
 

--- a/test/interceptor.js
+++ b/test/interceptor.js
@@ -222,9 +222,9 @@ describe('interceptor', () => {
       expect(mocked.called, 'spawned called').to.equal(true)
       expect(caught.message, 'error message').to.equal(error.message)
       expect(spawned.killed).to.not.equal(true)
-      expect(spawned.stdin).to.equal(undefined)
-      expect(spawned.stdout).to.equal(undefined)
-      expect(spawned.stderr).to.equal(undefined)
+      expect(spawned.stdin).to.not.equal(undefined)
+      expect(spawned.stdout).to.not.equal(undefined)
+      expect(spawned.stderr).to.not.equal(undefined)
     })
   })
 

--- a/test/interceptor.js
+++ b/test/interceptor.js
@@ -110,7 +110,7 @@ describe('interceptor', () => {
       expect(spawned.connected, 'connected').to.equal(true)
       await Fixtures.exitPromise(spawned)
       const after = new Date()
-      expect(after - before).to.be.at.least(delay)
+      expect(after - before).to.be.at.least(delay - 10)
     })
   })
 
@@ -193,7 +193,7 @@ describe('interceptor', () => {
       const spawned = cp.spawn(command)
       const caught = await Fixtures.errorPromise(spawned)
       const after = new Date()
-      expect(after - before).to.be.at.least(delay)
+      expect(after - before).to.be.at.least(delay - 10)
       expect(caught.message).to.equal(error.message)
     })
 


### PR DESCRIPTION
This makes `spawnError` pay attention to the `delay` and `exitOnSignal`
behavior, to postpone the error if needed.