### PR TITLE
fix(exit): os-specific behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ This can be either a number or a function that returns a number.  The
 function can also be async or return a Promise.  The function will be
 called with `this` set to the interceptor.
 
+Calling this will clear out any signal you set with `interceptor.signal`
+
 ### interceptor.signal(signal)
 
 Tells the interceptor what signal to exit with.  Defaults to null (exit

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ node.js child_process.spawn mocking library
 
 Spawk can be used to test modules that call spawn in isolation.
 
+Note: This module does its best to implement platform specific behaviors
+of (`child_process.spawn()`)[https://nodejs.org/api/child_process.html],
+anything that behaves differently is a
+(bug)[https://github.com/wraithgar/spawk/issues/new/choose].
+
 ## Example
 
 ```js
@@ -154,6 +159,8 @@ with no signal).
 This can be either a string or a function that returns a string.  The
 function can also be async or return a Promise.  The function will be
 called with `this` set to the interceptor.
+
+Calling this will clear out any code you set with `interceptor.exit`
 
 ### interceptor.stdout(data)
 

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -118,8 +118,9 @@ class API {
 
 class Interceptor {
   constructor (command, args, options) {
+    // TODO exitCode is null until exit time
     this.mocks = {
-      exitCode: 0,
+      exitCode: null,
       signal: null
     }
     this.delay = 0
@@ -139,6 +140,7 @@ class Interceptor {
   }
 
   set exitCode (code) {
+    this.mocks.signal = undefined
     this.mocks.exitCode = code
   }
 
@@ -151,6 +153,7 @@ class Interceptor {
   }
 
   set signal (signal) {
+    this.mocks.exitCode = undefined
     this.mocks.signal = signal
   }
 
@@ -227,8 +230,6 @@ class Interceptor {
       const [exitCode, signal, stdout, stderr] = await Promise.all(
         [this.exitCode, this.signal, this.stdout, this.stderr]
       )
-      this.child.exitCode = exitCode
-      this.child.signalCode = signal
       this.child.connected = false
       this.child.emit('disconnect')
       if (stdout) {
@@ -238,9 +239,21 @@ class Interceptor {
       if (stderr) {
         this.child.stderr.write(stderr)
       }
+      let emitCode
+      if (signal) {
+        this.child.signalCode = signal
+        emitCode = this.child.signalCode
+        // istanbul ignore next
+        if (process.platform === 'win32') {
+          emitCode = 1
+        }
+      } else {
+        this.child.exitCode = exitCode || 0
+        emitCode = this.child.exitCode
+      }
       this.child.stderr.end()
-      this.child.emit('exit', exitCode, signal)
-      this.child.emit('close', exitCode, signal)
+      this.child.emit('exit', emitCode)
+      this.child.emit('close', emitCode)
     }
 
     if (this.spawnError && !this.exitOnSignal) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -118,7 +118,6 @@ class API {
 
 class Interceptor {
   constructor (command, args, options) {
-    // TODO exitCode is null until exit time
     this.mocks = {
       exitCode: null,
       signal: null

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -239,21 +239,20 @@ class Interceptor {
       if (stderr) {
         this.child.stderr.write(stderr)
       }
-      let emitCode
-      if (signal) {
-        this.child.signalCode = signal
-        emitCode = this.child.signalCode
-        // istanbul ignore next
-        if (process.platform === 'win32') {
-          emitCode = 1
-        }
-      } else {
-        this.child.exitCode = exitCode || 0
-        emitCode = this.child.exitCode
-      }
       this.child.stderr.end()
-      this.child.emit('exit', emitCode)
-      this.child.emit('close', emitCode)
+
+      this.child.exitCode = exitCode || 0
+      this.child.signalCode = signal
+      let emitCode = this.child.exitCode
+      let emitSignal = this.child.signalCode
+      // istanbul ignore next
+      if (emitSignal && process.platform === 'win32') {
+        emitCode = 1
+        emitSignal = undefined
+      }
+
+      this.child.emit('exit', emitCode, emitSignal)
+      this.child.emit('close', emitCode, emitSignal)
     }
 
     if (this.spawnError && !this.exitOnSignal) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -240,7 +240,9 @@ class Interceptor {
       }
       this.child.stderr.end()
 
-      this.child.exitCode = exitCode || 0
+      if (!signal) {
+        this.child.exitCode = exitCode || 0
+      }
       this.child.signalCode = signal
       let emitCode = this.child.exitCode
       let emitSignal = this.child.signalCode

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -99,7 +99,9 @@ const fixtures = {
   }),
 
   exitPromise: (spawned) => new Promise((resolve) => {
-    spawned.on('exit', resolve)
+    spawned.on('exit', (code, signal) => {
+      resolve({ code, signal })
+    })
   }),
 
   spawnPromise: (spawned) => new Promise((resolve) => {

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -99,9 +99,7 @@ const fixtures = {
   }),
 
   exitPromise: (spawned) => new Promise((resolve) => {
-    spawned.on('exit', (code, signal) => {
-      resolve({ code, signal })
-    })
+    spawned.on('exit', resolve)
   }),
 
   spawnPromise: (spawned) => new Promise((resolve) => {

--- a/test/interceptor.js
+++ b/test/interceptor.js
@@ -27,7 +27,7 @@ describe('interceptor', function () {
     const stdoutPromise = Fixtures.stdoutPromise(spawned)
     const stderrPromise = Fixtures.stderrPromise(spawned)
 
-    const code = await exitPromise
+    const { code } = await exitPromise
     await spawnPromise
     await disconnectPromise
     await closePromise
@@ -57,7 +57,7 @@ describe('interceptor', function () {
     expect(mock.calledWith).to.equal(undefined)
 
     const spawned = cp.spawn(command, args, options)
-    const code = await Fixtures.exitPromise(spawned)
+    const { code } = await Fixtures.exitPromise(spawned)
 
     expect(code, 'exit code').to.equal(exitCode)
     expect(calledWith.command).to.equal(command)
@@ -73,7 +73,7 @@ describe('interceptor', function () {
       const command = Fixtures.command()
       const mock = spawk.spawn(command).exit(exitCode)
       const spawned = cp.spawn(command)
-      const code = await Fixtures.exitPromise(spawned)
+      const { code } = await Fixtures.exitPromise(spawned)
 
       expect(code, 'exit code').to.equal(exitCode)
       expect(mock.called).to.equal(true)
@@ -85,7 +85,7 @@ describe('interceptor', function () {
       const exitFn = () => exitCode
       const mock = spawk.spawn(command).exit(exitFn)
       const spawned = cp.spawn(command)
-      const code = await Fixtures.exitPromise(spawned)
+      const { code } = await Fixtures.exitPromise(spawned)
 
       expect(code, 'exit code').to.equal(exitCode)
       expect(mock.called).to.equal(true)
@@ -97,7 +97,7 @@ describe('interceptor', function () {
       const exitFn = () => Promise.resolve(exitCode)
       const mock = spawk.spawn(command).exit(exitFn)
       const spawned = cp.spawn(command)
-      const code = await Fixtures.exitPromise(spawned)
+      const { code } = await Fixtures.exitPromise(spawned)
 
       expect(code, 'exit code').to.equal(exitCode)
       expect(mock.called).to.equal(true)
@@ -132,7 +132,7 @@ describe('interceptor', function () {
       await Fixtures.delay(50)
       spawned.kill(exitSignal)
 
-      const signal = await Fixtures.exitPromise(spawned)
+      const { signal } = await Fixtures.exitPromise(spawned)
 
       expect(signal, 'exit signal').to.equal(exitSignal)
       expect(spawned.killed, 'killed').to.equal(true)
@@ -152,7 +152,7 @@ describe('interceptor', function () {
       await Fixtures.delay(50)
       spawned.kill(exitSignal)
 
-      const signal = await Fixtures.exitPromise(spawned)
+      const { signal } = await Fixtures.exitPromise(spawned)
 
       expect(signal, 'exit signal').to.equal(1)
       expect(spawned.killed, 'killed').to.equal(true)
@@ -173,7 +173,7 @@ describe('interceptor', function () {
       await Fixtures.delay(50)
       spawned.kill(exitSignal)
 
-      const signal = await Fixtures.exitPromise(spawned)
+      const { signal } = await Fixtures.exitPromise(spawned)
 
       expect(signal, 'exit signal').to.equal(otherSignal)
       expect(mocked.called, 'spawned called').to.equal(true)
@@ -194,7 +194,7 @@ describe('interceptor', function () {
       await Fixtures.delay(50)
       spawned.kill(exitSignal)
 
-      const signal = await Fixtures.exitPromise(spawned)
+      const { signal } = await Fixtures.exitPromise(spawned)
 
       expect(signal, 'exit signal').to.equal(1)
       expect(mocked.called, 'spawned called').to.equal(true)
@@ -215,7 +215,7 @@ describe('interceptor', function () {
       await Fixtures.delay(50)
       spawned.kill(exitSignal)
 
-      const signal = await Fixtures.exitPromise(spawned)
+      const { signal } = await Fixtures.exitPromise(spawned)
 
       expect(signal, 'exit signal').to.equal(otherSignal)
       expect(mocked.called, 'spawned called').to.equal(true)
@@ -235,7 +235,7 @@ describe('interceptor', function () {
       await Fixtures.delay(50)
       spawned.kill(exitSignal)
 
-      const signal = await Fixtures.exitPromise(spawned)
+      const { signal } = await Fixtures.exitPromise(spawned)
 
       expect(signal, 'exit signal').to.equal(1)
       expect(mocked.called, 'spawned called').to.equal(true)
@@ -300,7 +300,7 @@ describe('interceptor', function () {
       const command = Fixtures.command()
       const mock = spawk.spawn(command).signal(exitSignal)
       const spawned = cp.spawn(command)
-      const signal = await Fixtures.exitPromise(spawned)
+      const { signal } = await Fixtures.exitPromise(spawned)
 
       expect(signal, 'exit signal').to.equal(exitSignal)
       expect(mock.called).to.equal(true)
@@ -314,7 +314,7 @@ describe('interceptor', function () {
       const command = Fixtures.command()
       const mock = spawk.spawn(command).signal(exitSignal)
       const spawned = cp.spawn(command)
-      const signal = await Fixtures.exitPromise(spawned)
+      const { signal } = await Fixtures.exitPromise(spawned)
 
       expect(signal, 'exit signal').to.equal(1)
       expect(mock.called).to.equal(true)
@@ -329,7 +329,7 @@ describe('interceptor', function () {
       const signalFn = () => exitSignal
       const mock = spawk.spawn(command).signal(signalFn)
       const spawned = cp.spawn(command)
-      const signal = await Fixtures.exitPromise(spawned)
+      const { signal } = await Fixtures.exitPromise(spawned)
 
       expect(signal, 'exit signal').to.equal(exitSignal)
       expect(mock.called).to.equal(true)
@@ -344,7 +344,7 @@ describe('interceptor', function () {
       const signalFn = () => exitSignal
       const mock = spawk.spawn(command).signal(signalFn)
       const spawned = cp.spawn(command)
-      const signal = await Fixtures.exitPromise(spawned)
+      const { signal } = await Fixtures.exitPromise(spawned)
 
       expect(signal, 'exit signal').to.equal(1)
       expect(mock.called).to.equal(true)
@@ -359,7 +359,7 @@ describe('interceptor', function () {
       const signalFn = () => Promise.resolve(exitSignal)
       const mock = spawk.spawn(command).signal(signalFn)
       const spawned = cp.spawn(command)
-      const signal = await Fixtures.exitPromise(spawned)
+      const { signal } = await Fixtures.exitPromise(spawned)
 
       expect(signal, 'exit signal').to.equal(exitSignal)
       expect(mock.called).to.equal(true)
@@ -374,7 +374,7 @@ describe('interceptor', function () {
       const signalFn = () => Promise.resolve(exitSignal)
       const mock = spawk.spawn(command).signal(signalFn)
       const spawned = cp.spawn(command)
-      const signal = await Fixtures.exitPromise(spawned)
+      const { signal } = await Fixtures.exitPromise(spawned)
 
       expect(signal, 'exit signal').to.equal(1)
       expect(mock.called).to.equal(true)
@@ -387,7 +387,7 @@ describe('interceptor', function () {
       const output = Fixtures.output()
       const mock = spawk.spawn(command).stdout(output)
       const spawned = cp.spawn(command)
-      const code = await Fixtures.exitPromise(spawned)
+      const { code } = await Fixtures.exitPromise(spawned)
       const stdout = await Fixtures.stdoutPromise(spawned)
 
       expect(code, 'exit code').to.equal(0)
@@ -400,7 +400,7 @@ describe('interceptor', function () {
       const output = Fixtures.output()
       const mock = spawk.spawn(command).stdout(Buffer.from(output))
       const spawned = cp.spawn(command)
-      const code = await Fixtures.exitPromise(spawned)
+      const { code } = await Fixtures.exitPromise(spawned)
       const stdout = await Fixtures.stdoutPromise(spawned)
 
       expect(code, 'exit code').to.equal(0)
@@ -414,7 +414,7 @@ describe('interceptor', function () {
       const outputFn = () => output
       const mock = spawk.spawn(command).stdout(outputFn)
       const spawned = cp.spawn(command)
-      const code = await Fixtures.exitPromise(spawned)
+      const { code } = await Fixtures.exitPromise(spawned)
       const stdout = await Fixtures.stdoutPromise(spawned)
 
       expect(code, 'exit code').to.equal(0)
@@ -428,7 +428,7 @@ describe('interceptor', function () {
       const outputFn = () => Promise.resolve(output)
       const mock = spawk.spawn(command).stdout(outputFn)
       const spawned = cp.spawn(command)
-      const code = await Fixtures.exitPromise(spawned)
+      const { code } = await Fixtures.exitPromise(spawned)
       const stdout = await Fixtures.stdoutPromise(spawned)
 
       expect(code, 'exit code').to.equal(0)
@@ -443,7 +443,7 @@ describe('interceptor', function () {
       const output = Fixtures.output()
       const mock = spawk.spawn(command).stderr(output)
       const spawned = cp.spawn(command)
-      const code = await Fixtures.exitPromise(spawned)
+      const { code } = await Fixtures.exitPromise(spawned)
       const stderr = await Fixtures.stderrPromise(spawned)
 
       expect(code, 'exit code').to.equal(0)
@@ -456,7 +456,7 @@ describe('interceptor', function () {
       const output = Fixtures.output()
       const mock = spawk.spawn(command).stderr(Buffer.from(output))
       const spawned = cp.spawn(command)
-      const code = await Fixtures.exitPromise(spawned)
+      const { code } = await Fixtures.exitPromise(spawned)
       const stderr = await Fixtures.stderrPromise(spawned)
 
       expect(code, 'exit code').to.equal(0)
@@ -470,7 +470,7 @@ describe('interceptor', function () {
       const outputFn = () => output
       const mock = spawk.spawn(command).stderr(outputFn)
       const spawned = cp.spawn(command)
-      const code = await Fixtures.exitPromise(spawned)
+      const { code } = await Fixtures.exitPromise(spawned)
       const stderr = await Fixtures.stderrPromise(spawned)
 
       expect(code, 'exit code').to.equal(0)
@@ -484,7 +484,7 @@ describe('interceptor', function () {
       const outputFn = () => Promise.resolve(output)
       const mock = spawk.spawn(command).stderr(outputFn)
       const spawned = cp.spawn(command)
-      const code = await Fixtures.exitPromise(spawned)
+      const { code } = await Fixtures.exitPromise(spawned)
       const stderr = await Fixtures.stderrPromise(spawned)
 
       expect(code, 'exit code').to.equal(0)

--- a/test/interceptor.js
+++ b/test/interceptor.js
@@ -129,6 +129,7 @@ describe('interceptor', function () {
       const mocked = spawk.spawn(command).exitOnSignal(exitSignal)
       const spawned = cp.spawn(command)
 
+      expect(spawned.exitCode, 'exitCode').to.equal(null)
       await Fixtures.delay(50)
       spawned.kill(exitSignal)
 

--- a/test/interceptor.js
+++ b/test/interceptor.js
@@ -152,9 +152,10 @@ describe('interceptor', function () {
       await Fixtures.delay(50)
       spawned.kill(exitSignal)
 
-      const { signal } = await Fixtures.exitPromise(spawned)
+      const { code, signal } = await Fixtures.exitPromise(spawned)
 
-      expect(signal, 'exit signal').to.equal(1)
+      expect(code, 'exit code').to.equal(1)
+      expect(signal, 'exit signal').to.equal(undefined)
       expect(spawned.killed, 'killed').to.equal(true)
       expect(mocked.called, 'spawned called').to.equal(true)
     })
@@ -194,9 +195,10 @@ describe('interceptor', function () {
       await Fixtures.delay(50)
       spawned.kill(exitSignal)
 
-      const { signal } = await Fixtures.exitPromise(spawned)
+      const { code, signal } = await Fixtures.exitPromise(spawned)
 
-      expect(signal, 'exit signal').to.equal(1)
+      expect(code, 'exit code').to.equal(1)
+      expect(signal, 'exit signal').to.equal(undefined)
       expect(mocked.called, 'spawned called').to.equal(true)
       expect(spawned.killed).to.equal(true)
     })
@@ -235,9 +237,10 @@ describe('interceptor', function () {
       await Fixtures.delay(50)
       spawned.kill(exitSignal)
 
-      const { signal } = await Fixtures.exitPromise(spawned)
+      const { code, signal } = await Fixtures.exitPromise(spawned)
 
-      expect(signal, 'exit signal').to.equal(1)
+      expect(code, 'exit code').to.equal(1)
+      expect(signal, 'exit signal').to.equal(undefined)
       expect(mocked.called, 'spawned called').to.equal(true)
     })
   })
@@ -314,9 +317,10 @@ describe('interceptor', function () {
       const command = Fixtures.command()
       const mock = spawk.spawn(command).signal(exitSignal)
       const spawned = cp.spawn(command)
-      const { signal } = await Fixtures.exitPromise(spawned)
+      const { code, signal } = await Fixtures.exitPromise(spawned)
 
-      expect(signal, 'exit signal').to.equal(1)
+      expect(code, 'exit code').to.equal(1)
+      expect(signal, 'exit signal').to.equal(undefined)
       expect(mock.called).to.equal(true)
     })
 
@@ -344,9 +348,10 @@ describe('interceptor', function () {
       const signalFn = () => exitSignal
       const mock = spawk.spawn(command).signal(signalFn)
       const spawned = cp.spawn(command)
-      const { signal } = await Fixtures.exitPromise(spawned)
+      const { code, signal } = await Fixtures.exitPromise(spawned)
 
-      expect(signal, 'exit signal').to.equal(1)
+      expect(code, 'exit code').to.equal(1)
+      expect(signal, 'exit signal').to.equal(undefined)
       expect(mock.called).to.equal(true)
     })
 
@@ -374,9 +379,10 @@ describe('interceptor', function () {
       const signalFn = () => Promise.resolve(exitSignal)
       const mock = spawk.spawn(command).signal(signalFn)
       const spawned = cp.spawn(command)
-      const { signal } = await Fixtures.exitPromise(spawned)
+      const { code, signal } = await Fixtures.exitPromise(spawned)
 
-      expect(signal, 'exit signal').to.equal(1)
+      expect(code, 'exit code').to.equal(1)
+      expect(signal, 'exit signal').to.equal(undefined)
       expect(mock.called).to.equal(true)
     })
   })


### PR DESCRIPTION
The exit/close events only receive one param, either the signal or exit
code.  Except in windows.  This brings spawk into alignment with real OS
behavior
