### PR TITLE
fix(options): clone the stdio array instead of modifying it in place

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -14,7 +14,7 @@ function stdios (options = {}) {
   }
 
   if (Array.isArray(options.stdio)) {
-    stdio = options.stdio
+    stdio = [...options.stdio]
   }
 
   if (stdio[0] === 'inherit') {


### PR DESCRIPTION
when `options.stdio` was defined as an array we were modifying that array in place. instead of mutating the original array, what we really want is to create a new array so the user's original options are preserved.