### PR TITLE
fix(options): clone the stdio array instead of modifying it in place

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -14,7 +14,7 @@ function stdios (options = {}) {
   }
 
   if (Array.isArray(options.stdio)) {
-    stdio = options.stdio
+    stdio = [...options.stdio]
   }
 
   if (stdio[0] === 'inherit') {

--- a/test/interceptor.js
+++ b/test/interceptor.js
@@ -556,19 +556,24 @@ describe('interceptor', function () {
 
     it('array: inherit, pipe, pipe', function () {
       const command = Fixtures.command()
+      const stdio = ['inherit', 'pipe', 'pipe']
       spawk.spawn(command)
-      const spawned = cp.spawn(command, null, { stdio: ['inherit', 'pipe', 'pipe'] })
+      const spawned = cp.spawn(command, null, { stdio })
       expect(spawned.stdin, 'spawed stdin').to.equal(null)
       expect(spawned.stdout, 'spawed stdout').to.not.equal(null)
       expect(spawned.stderr, 'spawed stderr').to.not.equal(null)
+      expect(stdio, 'original stdio array').to.deep.equal(['inherit', 'pipe', 'pipe'])
     })
+
     it('array: pipe, inherit, pipe', function () {
       const command = Fixtures.command()
+      const stdio = ['pipe', 'inherit', 'pipe']
       spawk.spawn(command)
-      const spawned = cp.spawn(command, null, { stdio: ['pipe', 'inherit', 'pipe'] })
+      const spawned = cp.spawn(command, null, { stdio })
       expect(spawned.stdin, 'spawed stdin').to.not.equal(null)
       expect(spawned.stdout, 'spawed stdout').to.equal(null)
       expect(spawned.stderr, 'spawed stderr').to.not.equal(null)
+      expect(stdio, 'original stdio array').to.deep.equal(['pipe', 'inherit', 'pipe'])
     })
   })
 })


### PR DESCRIPTION
when  options.stdio  was defined as an array we were modifying that array in
place. instead of mutating the original array, what we really want is to
create a new array so the user's original options are preserved.