### PR TITLE
fix(error): emit error event at correct time

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -301,9 +301,18 @@ class Interceptor {
     }
 
     if (this.spawnError && !this.exitOnSignal) {
-      setTimeout(() => {
-        this.child.emit('error', this.spawnError)
-      }, this.delay)
+      if (!this.delay) {
+        // This is very intentional, it forces consumers to set their event
+        // listeners IMMEDIATELY after calling child_process.spawn().
+        // See: https://nodejs.dev/learn/understanding-setimmediate
+        process.nextTick(() => {
+          this.child.emit('error', this.spawnError)
+        }, this.delay)
+      } else {
+        setTimeout(() => {
+          this.child.emit('error', this.spawnError)
+        }, this.delay)
+      }
     } else {
       this.child.connected = true
       this.child.stdio = stdios(options)
@@ -315,7 +324,10 @@ class Interceptor {
         if (!this.spawnError && (signal === this.exitOnSignal)) {
           this.child.killed = true
         }
-        this.child.emit(signal, signal)
+        // process.nextTick to give the caller a chance to set up listeners
+        process.nextTick(() => {
+          this.child.emit(signal, signal)
+        })
       }
       // process.nextTick to give the caller a chance to set up listeners
       process.nextTick(() => {


### PR DESCRIPTION
This will force consumers to set up their error event listener
immediately after calling `.spawn()`.
